### PR TITLE
Changed crossbeam dependency to newest version and fixed a compiler warning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ strided = "*"
 num = "*"
 num_cpus = "0.2"
 [dependencies]
-crossbeam = "0.1"
+crossbeam = "^0.2"
 
 [features]
 unstable = []

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -487,7 +487,7 @@ impl Pool {
     ///
     /// The job must take pains to ensure `main_fn` doesn't quit
     /// before the workers do.
-    pub unsafe fn execute<'pool, 'f, A, GenFn, WorkerFn, MainFn>(
+    unsafe fn execute<'pool, 'f, A, GenFn, WorkerFn, MainFn>(
         &'pool mut self, scope: &Scope<'f>, data: A, gen_fn: GenFn, main_fn: MainFn) -> JobHandle<'pool, 'f>
 
         where A: 'f + Send,


### PR DESCRIPTION
Hello,

This project doesn't compile anymore with:

```
rustc 1.11.0-nightly (a967611d8 2016-05-30)
```

and the reason is that `crossbeam 0.1` fails to compile with the newest Rust version. It looks like a type changed its size and therefore a transmute fails:

```
$home\.cargo\registry\src\github.com-1ecc6299db9ec823\crossbeam-0.1.6\src\sync\seg_queue.rs:34:29: 34:43 error: transmute called with differently sized types: [usize; 32] (2048 bits) to [std::sync::atomic::AtomicBool; 32] (256 bits) [E0512]
$home\.cargo\registry\src\github.com-1ecc6299db9ec823\crossbeam-0.1.6\src\sync\seg_queue.rs:34             ready: unsafe { mem::transmute([0usize; SEG_SIZE]) },
                                                                                                                                       ^~~~~~~~~~~~~~
$home\.cargo\registry\src\github.com-1ecc6299db9ec823\crossbeam-0.1.6\src\sync\seg_queue.rs:34:29: 34:43 help: run `rustc --explain E0512` to see a detailed explanation
error: aborting due to previous error
   Compiling simple_parallel v0.3.0 (file:///$project/simple_parallel)
error: extern location for crossbeam does not exist: $project\simple_parallel\target\debug\deps\libcrossbeam-d52266573116b0f7.rlib
src\lib.rs:188:1: 188:24 error: can't find crate for `crossbeam` [E0463]
src\lib.rs:188 extern crate crossbeam;
               ^~~~~~~~~~~~~~~~~~~~~~~
error: aborting due to 2 previous errors
```

The pull request contains therefore an update to `crossbeam 0.2` and it fixes a compiler warning by making `execute` private since `WorkerId` is a private type and therefore I assumed that the whole function should in fact be private.
- Christian
